### PR TITLE
Fix Schwab typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Reports bot
 ## General Outline
 ### One Liner
-- Once triggered, pull Shwab account data and place data into a google sheets page.
+- Once triggered, pull Schwab account data and place data into a google sheets page.
 
 ### Goals / Requirements 
 1. Formatting data, combine same trades to single lines for automatic percentage gain/loss calculations


### PR DESCRIPTION
## Summary
- fix Schwab typo in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8e53318083238773c09f4a25bcb4