### PR TITLE
Add configuration docs and example env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Example environment configuration for reports-bot
+# Copy this file to config/.env and fill in your values.
+
+GSHEETS_CREDENTIALS=/absolute/path/to/service_account.json
+GSHEETS_SHEET_ID=your_google_sheet_id
+GSHEETS_SHEET_NAME=Sheet1
+
+SCHWAB_APP_KEY=your_schwab_key
+SCHWAB_APP_SECRET=your_schwab_secret
+
+DATABASE_PATH=data/orders.db
+LOOP_TYPE=DAILY
+HOUR_OF_DAY=17
+TIME_DELTA=24
+LOOP_FREQUENCY=60

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ trades.txt
 venv
 weekly-reports-bot.json
 *.pyc
+config/.env
+
+src/

--- a/config/config.md
+++ b/config/config.md
@@ -1,1 +1,20 @@
-# Create Guide for uploading gsheet key and template for .env file
+# Configuration Guide
+
+Create a `config/.env` file (not committed to version control) with the following keys. You can use `.env.example` as a starting point.
+
+| Key | Description |
+| --- | ----------- |
+| `GSHEETS_CREDENTIALS` | Path to the Google service account JSON file used for Sheets access. |
+| `GSHEETS_SHEET_ID` | ID of the spreadsheet where reports are written. |
+| `GSHEETS_SHEET_NAME` | Worksheet name within the spreadsheet. |
+| `SCHWAB_APP_KEY` | Schwab API application key. |
+| `SCHWAB_APP_SECRET` | Schwab API secret. |
+| `DATABASE_PATH` | Location of the SQLite database file. Defaults to `data/orders.db`. |
+| `LOOP_TYPE` | `DAILY` to run once per day or `DEBUG` for a single run. Defaults to `DAILY`. |
+| `HOUR_OF_DAY` | Hour (0-23) to trigger the daily run. Defaults to `17`. |
+| `TIME_DELTA` | Number of past hours of orders to fetch from Schwab. Defaults to `24`. |
+| `LOOP_FREQUENCY` | Interval in seconds between scheduler checks. Defaults to `60`. |
+
+Copy `.env.example` to `config/.env` and update the values accordingly. The application loads this file at startup.
+
+To use these variables securely in Codex, store the credentials as [secrets](https://docs.docker.com/engine/swarm/secrets/). When running the container, map the secrets or environment values rather than committing them to the repository.

--- a/readme.md
+++ b/readme.md
@@ -8,3 +8,8 @@
 2. Formatting data, for optimal graphing of data with google sheets
 3. Creation of new data page for each report? 
 4. Automatic date range from last trigger to current trigger
+
+## Configuration
+Copy `.env.example` to `config/.env` and adjust the values to match your environment. See `config/config.md` for a detailed description of each key.
+
+When running inside Codex, provide secrets as environment variables instead of editing the file directly. This keeps credentials out of source control and build logs.


### PR DESCRIPTION
## Summary
- document environment variables in `config/config.md`
- add setup notes to `readme.md`
- provide `.env.example` with all keys
- ignore local `config/.env` and `src/` directories

## Testing
- `PYTHONPATH=src/bot-app pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8f5d68c883238dbbd6535da4c2bf